### PR TITLE
Fixed hyphenation for models that have multi-word names

### DIFF
--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -4,7 +4,7 @@ export default DS.RESTAdapter.extend({
   defaultSerializer: '-fhir',
 
   pathForType: function(type){
-    return Ember.String.capitalize(type);
+    return Ember.String.capitalize(Ember.String.camelize(type));
   },
 
 

--- a/addon/serializers/application.js
+++ b/addon/serializers/application.js
@@ -9,7 +9,7 @@ export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
       hash[key.camelize()] = hash[key];
     delete hash[key];
     }
-    hash.resourceType = snapshot.typeKey.capitalize();
+    hash.resourceType = snapshot.typeKey.camelize().capitalize();
 
     return hash;
 


### PR DESCRIPTION
HTTP requests for models with multi-word names were hyphenated.
E.g. the model that should have been "ProcedureRequest" was actually
"Procedure-request".
This was affecting the URL path for all HTTP requests, as well as the
resourceType attribute in the JSON body of POST requests.
