### PR TITLE
Fix to allow setting IDs for newly created records

### DIFF
--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -7,6 +7,14 @@ export default DS.RESTAdapter.extend({
     return Ember.String.capitalize(Ember.String.camelize(type));
   },
 
+  createRecord: function (store, type, snapshot) {
+    if (snapshot.id) {
+      // if we have set an ID on this record, use "update" instead of "create"
+      // (triggers a PUT instead of POST)
+      return this.updateRecord(store, type, snapshot);
+    }
+    return this._super(store, type, snapshot);
+  },
 
   buildURL: function(modelName, id, snapshot, requestType, query) {
     if(requestType === "fhirQuery"){


### PR DESCRIPTION
Previously, saving a new record would trigger a POST request to
the FHIR server. In the FHIR specification, the only way to create
a new record and assign it an ID is by using a PUT request. This
fix causes the adapter to use a PUT request when saving a new
record that has an ID that has been manually set. If no ID is set,
it defaults to a POST request which will auto-generate an ID.
